### PR TITLE
feat(home): disable locked levels & show first level as completed

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Mathi aprende a leer!</title>
   </head>
   <body>
-    <h1>Test-prod-check</h1>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/components/LinkButton.tsx
+++ b/src/components/LinkButton.tsx
@@ -5,8 +5,12 @@ import { Link as RouterLink, type LinkProps } from "react-router-dom";
 type LinkButtonProps = ButtonProps & LinkProps;
 
 export default function LinkButton(props: LinkButtonProps) {
-    const { to, ...rest } = props;
+    const { to, isDisabled, ...rest } = props;
     return (
-        <Button as={RouterLink as any} {...(rest as any)} to={to as any} />
+        <Button
+            {...rest}    
+            isDisabled={isDisabled}
+            {...(!isDisabled && { as: RouterLink, to })}
+        />
     );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,36 +1,46 @@
-// src/app/Home.tsx
-import { Box, Flex, Heading, Spinner } from "@chakra-ui/react";
-import LinkButton from "../components/LinkButton";
-import { useData } from "../context/DataContext";
-import { useProgress } from "../context/ProgressContext";
+// src/pages/Home.tsx
+import { Box, Button, Flex, Heading, Spinner } from "@chakra-ui/react"
+import LinkButton from "../components/LinkButton"
+import { useData } from "../context/DataContext"
+import { useProgress } from "../context/ProgressContext"
 
 export default function Home() {
     const { consonants, loading } = useData();
     const { progress, isUnlocked } = useProgress();
 
-    if (loading) return <Spinner size="xl" mt="40" />;
+    if (loading) return <Spinner size="xl" mt="40" />
 
     return (
         <Box p={6}>
             <Heading mb={6}>Elige una consonante</Heading>
             <Flex gap={4} wrap="wrap">
-                {consonants.map((c,idx) => (
+                {consonants.map((c, idx) => {
+                    const unlocked = isUnlocked(c.id, idx);
+                    const done = progress[c.id]?.done;
 
-                    // Home.tsx
-                    <LinkButton
-                        key={c.id}
-                        size="lg"
-
-                        isDisabled={!isUnlocked(c.id, idx)}
-                        variant={progress[c.id]?.done ? "solid" : "outline"}
-                        colorScheme={progress[c.id]?.done ? "teal" : "gray"}
-                        to={`/level/${c.id}/${c.words[0].id}`}
-                    >
-                        {c.id}
-                    </LinkButton>
-
-                ))}
+                    return unlocked ? (
+                        <LinkButton
+                            key={c.id}
+                            size="lg"
+                            variant={done ? "solid" : "outline"}
+                            colorScheme={done ? "teal" : "gray"}
+                            to={`/level/${c.id}/${c.words[0].id}`}
+                        >
+                            {c.id}
+                        </LinkButton>
+                    ) : (
+                        <Button
+                            key={c.id}
+                            size="lg"
+                            isDisabled
+                            variant="outline"
+                            colorScheme="gray"
+                        >
+                            {c.id}
+                        </Button>
+                    );
+                })}
             </Flex>
         </Box>
-    );
+    )
 }


### PR DESCRIPTION
- LinkButton now only wraps <RouterLink> when not disabled
- Locked consonants render as plain disabled <Button> (no navigation)
- First consonant (idx 0) now correctly shows “done” styling once completed