### PR TITLE
feat(database): migrate progress and badges to firestore, fully depre…

### DIFF
--- a/src/context/BadgeContext.tsx
+++ b/src/context/BadgeContext.tsx
@@ -6,10 +6,12 @@ import {
     useState,
     type ReactNode,
 } from "react";
-import { supabase } from "../lib/supabase";
+import { collection, doc, getDocs, setDoc } from "firebase/firestore";
+import { db } from "../lib/firebase";
+import { useAuth } from "./AuthContext";
 
 interface Badge {
-    id: string;
+    id: string; // En Firestore usaremos el levelId como ID del documento
     level_id: string;
     earned_at: string;
 }
@@ -29,68 +31,63 @@ export const useBadges = () => {
 };
 
 export function BadgeProvider({ children }: { children: ReactNode }) {
+    const { user } = useAuth();
     const [badges, setBadges] = useState<Badge[]>([]);
 
     const loadBadges = async () => {
-        const userResp = await supabase.auth.getUser();
-        const user = userResp.data.user;
-        if (!user) return;
-        const { data: rows, error } = await supabase
-            .from("user_badges")
-            .select("id, level_id, earned_at")
-            .eq("user_id", user.id)
-            .order("earned_at", { ascending: false });
-
-        if (error) throw error;
-
-        setBadges(
-            (rows || []).map((r: any) => ({
-                id: r.id,
-                level_id: r.level_id,
-                earned_at: r.earned_at,
-            }))
-        );
-    };
-
-    const grantBadge = async (levelId: string) => {
-        const userResp = await supabase.auth.getUser();
-        const user = userResp.data.user;
-        if (!user) throw new Error("No hay usuario autenticado");
-
-        // 1️⃣ Comprobar existencia previa
-        const { data: existing, error: fetchErr } = await supabase
-            .from("user_badges")
-            .select("id")
-            .eq("user_id", user.id)
-            .eq("level_id", levelId);
-
-        if (fetchErr) throw fetchErr;
-        if (existing && existing.length > 0) {
-            // Ya tiene la medalla: no insertar de nuevo
+        if (!user) {
+            setBadges([]);
             return;
         }
 
-        // 2️⃣ Insertar la nueva medalla
-        const { error: insertErr } = await supabase.from("user_badges").insert({
-            user_id: user.id,
-            level_id: levelId,
-        });
-
-        // Si el constraint UNIQUE se disparara igual, captura el error y sigue sin duplicar
-        if (insertErr && insertErr.code === "23505") {
-            // duplicate key
-            console.warn("Medalla ya existe, duplicado ignorado");
-        } else if (insertErr) {
-            throw insertErr;
+        try {
+            const badgesRef = collection(db, "users", user.uid, "badges");
+            const snapshot = await getDocs(badgesRef);
+            
+            const loadedBadges: Badge[] = [];
+            snapshot.forEach((docSnap) => {
+                loadedBadges.push(docSnap.data() as Badge);
+            });
+            
+            // Ordenamos por fecha de obtención (del más reciente al más antiguo)
+            loadedBadges.sort((a, b) => new Date(b.earned_at).getTime() - new Date(a.earned_at).getTime());
+            
+            setBadges(loadedBadges);
+        } catch (error) {
+            console.error("Error cargando medallas:", error);
         }
-
-        // 3️⃣ Recargar medallas para actualizar UI
-        await loadBadges();
     };
 
+    const grantBadge = async (levelId: string) => {
+        if (!user) throw new Error("No hay usuario autenticado para otorgar la medalla");
+
+        try {
+            // Creamos la referencia al documento de la medalla. 
+            // Usar levelId como ID del documento evita duplicados automáticamente en Firestore.
+            const badgeRef = doc(db, "users", user.uid, "badges", levelId);
+            
+            const newBadge: Badge = {
+                id: levelId,
+                level_id: levelId,
+                earned_at: new Date().toISOString()
+            };
+
+            // setDoc creará el documento o lo sobrescribirá (lo cual es seguro y evita errores de duplicación)
+            await setDoc(badgeRef, newBadge);
+            
+            // Recargamos las medallas para actualizar la UI (tu Perfil)
+            await loadBadges();
+            
+        } catch (error) {
+            console.error("Error al otorgar medalla:", error);
+            throw error;
+        }
+    };
+
+    // Cargar medallas automáticamente cuando cambia el usuario
     useEffect(() => {
-        loadBadges().catch(console.error);
-    }, []);
+        loadBadges();
+    }, [user]);
 
     return (
         <BadgeContext.Provider value={{ badges, loadBadges, grantBadge }}>

--- a/src/context/ProgressContext.tsx
+++ b/src/context/ProgressContext.tsx
@@ -6,7 +6,9 @@ import {
     useState,
     type ReactNode,
 } from "react";
-import { supabase } from "../lib/supabase";
+import { collection, doc, getDocs, setDoc } from "firebase/firestore";
+import { db } from "../lib/firebase";
+import { useAuth } from "./AuthContext"; // Importamos tu adaptador de sesión
 import { consonantList } from "../data/consonants";
 
 type ProgressRow = {
@@ -20,10 +22,7 @@ type ProgressState = Record<string, ProgressRow>;
 interface ProgressCtx {
     progress: ProgressState;
     isUnlocked: (consonantId: string, idx: number) => boolean;
-    completeWord: (
-        consonantId: string,
-        totalWords: number
-    ) => Promise<void>;
+    completeWord: (consonantId: string, totalWords: number) => Promise<void>;
 }
 
 const ProgressContext = createContext<ProgressCtx | undefined>(undefined);
@@ -35,61 +34,72 @@ export const useProgress = () => {
 };
 
 export function ProgressProvider({ children }: { children: ReactNode }) {
+    const { user } = useAuth(); // Extraemos el usuario actual
     const [progress, setProgress] = useState<ProgressState>({});
 
-    /** 1️⃣ Carga inicial desde Supabase */
+    /** 1️⃣ Carga inicial desde Firestore */
     useEffect(() => {
+        // Si no hay usuario, limpiamos el progreso (ej: al cerrar sesión)
+        if (!user) {
+            setProgress({});
+            return;
+        }
+
         (async () => {
-            const { data: rows, error } = await supabase
-                .from("user_progress")
-                .select("*");
-            if (error) {
-                console.error(error);
-                return;
+            try {
+                // Buscamos en la subcolección privada del usuario
+                const progressRef = collection(db, "users", user.uid, "progress");
+                const snapshot = await getDocs(progressRef);
+
+                const map: ProgressState = {};
+                snapshot.forEach((docSnap) => {
+                    const data = docSnap.data() as ProgressRow;
+                    map[data.consonant] = data;
+                });
+
+                setProgress(map);
+            } catch (error) {
+                console.error("Error cargando progreso de Firestore:", error);
             }
-            const map: ProgressState = {};
-            rows?.forEach((r) => {
-                map[r.consonant] = r;
-            });
-            setProgress(map);
         })();
-    }, []);
+    }, [user]); // Se vuelve a ejecutar si cambia el usuario
 
     /** 2️⃣ Marcar la siguiente palabra (y nivel) como completado */
-    const completeWord = async (
-        consonantId: string,
-        totalWords: number
-    ) => {
+    const completeWord = async (consonantId: string, totalWords: number) => {
+        if (!user) throw new Error("Debes iniciar sesión para guardar progreso");
+
         const current = progress[consonantId] || {
             consonant: consonantId,
             word_index: 0,
             done: false,
         };
+
         const nextIndex = current.word_index + 1;
         const done = nextIndex >= totalWords;
 
-        // upsert a user_progress (supabase-js v2)
-        const { error } = await supabase
-            .from("user_progress")
-            .upsert({
-                user_id: (await supabase.auth.getUser()).data.user!.id,
-                consonant: consonantId,
-                word_index: nextIndex,
-                done,
-            });
-        if (error) throw error;
+        const newProgressData: ProgressRow = {
+            consonant: consonantId,
+            word_index: nextIndex,
+            done,
+        };
 
-        setProgress((prev) => ({
-            ...prev,
-            [consonantId]: { consonant: consonantId, word_index: nextIndex, done },
-        }));
+        try {
+            // Guardamos en Firestore usando setDoc con merge (el equivalente a 'upsert')
+            const docRef = doc(db, "users", user.uid, "progress", consonantId);
+            await setDoc(docRef, newProgressData, { merge: true });
+
+            // Actualizamos la UI inmediatamente
+            setProgress((prev) => ({
+                ...prev,
+                [consonantId]: newProgressData,
+            }));
+        } catch (error) {
+            console.error("Error guardando progreso:", error);
+            throw error;
+        }
     };
 
-    /**
-     * 3️⃣ Lógica de desbloqueo:
-     *    - El idx=0 (primera consonante) siempre desbloqueada.
-     *    - Cualquier idx>0 solo si la anterior .done === true.
-     */
+    /** 3️⃣ Lógica de desbloqueo (Intacta) */
     const isUnlocked = (_cons: string, idx: number) => {
         if (idx === 0) return true;
         const prevCons = consonantList[idx - 1];
@@ -97,9 +107,7 @@ export function ProgressProvider({ children }: { children: ReactNode }) {
     };
 
     return (
-        <ProgressContext.Provider
-            value={{ progress, isUnlocked, completeWord }}
-        >
+        <ProgressContext.Provider value={{ progress, isUnlocked, completeWord }}>
             {children}
         </ProgressContext.Provider>
     );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,29 +17,25 @@ import { BadgeProvider } from "./context/BadgeContext";
 console.log("[main] rendering");
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  
+
   <React.StrictMode>
     <ChakraProvider theme={theme}>
-      <ProgressProvider>
-        <LivesProvider>
+      <BrowserRouter>
+        <AuthProvider>
+          <DataProvider>
+            <ProgressProvider>
+              <BadgeProvider>
+                <LivesProvider>
 
+                    <App />
 
-        <BrowserRouter>
-          <AuthProvider>
-            <BadgeProvider>
-
-              <DataProvider>
-                <App />
-              </DataProvider>
-              
-            </BadgeProvider>
-          </AuthProvider>
-        </BrowserRouter>
-
-        </LivesProvider>
-      </ProgressProvider>
+                </LivesProvider>
+              </BadgeProvider>
+            </ProgressProvider>
+          </DataProvider>
+        </AuthProvider>
+      </BrowserRouter>
     </ChakraProvider>
   </React.StrictMode>
+
 );
-
-


### PR DESCRIPTION
## Objetivo
Derrotar al "Jefe Final" de la migración. Reemplazar la base de datos relacional de Supabase (PostgreSQL) por Cloud Firestore (NoSQL) para gestionar el progreso y las medallas de los usuarios en tiempo real, eliminando así el 100% de la dependencia de Supabase en la aplicación.

## Cambios Principales
* **Refactorización de Contextos:** Se reescribieron `ProgressContext.tsx` y `BadgeContext.tsx` para utilizar operaciones de Firestore (`getDocs`, `setDoc`, `collection`, `doc`) apuntando a subcolecciones privadas por usuario (`users/{uid}/progress` y `users/{uid}/badges`).
* **Inyección de Dependencias:** Se reorganizó el árbol de `Providers` en `main.tsx` para asegurar que el `AuthProvider` envuelva correctamente al resto de los contextos, evitando errores de inicialización y renderizado.
* **Seguridad (Cloud Rules):** Se implementaron reglas de seguridad en Firestore para garantizar que cada usuario (niño) solo pueda leer y escribir en su propia "carpeta" privada.
* **Limpieza de Código:** Eliminación total de llamadas a `supabase.auth.getUser()` y dependencias legacy.

## Cómo probar esto
1. Iniciar el servidor local (`pnpm dev`).
2. Completar las palabras del primer nivel (Consonante "M").
3. Verificar que el nivel "P" se desbloquea correctamente.
4. Refrescar la página (`F5`) y comprobar que el progreso persiste (lectura exitosa de Firestore).
5. Completar todas las palabras de un nivel y visitar `/profile` para confirmar que la medalla correspondiente fue otorgada y renderizada.